### PR TITLE
Add strategy memory with best/worst examples

### DIFF
--- a/conversation/gpt_wrapper.py
+++ b/conversation/gpt_wrapper.py
@@ -28,7 +28,7 @@ class GPTConversation:
         messages.append({
             "role": "developer",
             "content": f"""You are a conversational assistant designed to keep users engaged.
-{strategy.to_prompt()}
+{strategy.to_prompt_with_memory()}
 
 Keep responses concise (under 180 tokens).
 put normal talking glitches in bracket, like [laughter] [smirk] [cough] [ahhhh] [emmmm] etc.."""


### PR DESCRIPTION
## Summary
- extend `Strategy` to remember best and worst examples
- persist examples on disk via `StrategySpace`
- load strategy memories in orchestrator and add new examples after each turn
- include memory examples in GPT prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ad575e4a48329a6e5df3ed4609ea7