### PR TITLE
Add therapy-focused strategy settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,11 +35,46 @@ class RLConfig:
     use_ucb: bool = True
     ucb_confidence: float = 2.0
 
-# Communication Strategy Components
-TONES = ["playful", "naughty", "informational", "aggressive", "sarcastic", 'calm','kind', "confident","empathic"]
-TOPICS = ["facts", "story", "controversial", "nerdy","gen z", "boomer","high iq", "low iq", "autistic","professional"]
-EMOTIONS = ["happy", "sad", "serious", "scared","worry",  "whisper", "angry", "laughter","flirting","thoughtful"]
-HOOKS = ["hey [name]", "you know what?", "are you with me?", "listen", "look", "Oh my god", " i can  not believe it!","can you beleive it?", "not gonna lie"]
+# Communication Strategy Components tailored for a mental wellness chatbot
+# Tone choices emphasise calm and support
+TONES = [
+    "calming",
+    "supportive",
+    "empathetic",
+    "encouraging",
+    "non-judgmental",
+    "reflective",
+]
+
+# Topics focus on self‑care and common mental health themes
+TOPICS = [
+    "coping strategies",
+    "stress management",
+    "mindfulness",
+    "self-esteem",
+    "anxiety relief",
+    "goal setting",
+    "relationship issues",
+]
+
+# Emotions expressed by the assistant
+EMOTIONS = [
+    "hopeful",
+    "concerned",
+    "reassuring",
+    "curious",
+    "uplifting",
+    "soothing",
+]
+
+# Hooks used to gently start or continue the conversation
+HOOKS = [
+    "let's take a deep breath together",
+    "how are you feeling right now?",
+    "it's okay to feel this way",
+    "tell me more about that",
+    "I'm here to listen",
+]
 
 
 # UI Configuration

--- a/rl/strategy.py
+++ b/rl/strategy.py
@@ -25,14 +25,12 @@ class Strategy:
     def to_prompt(self) -> str:
         """Convert strategy to simplified GPT system prompt."""
         return (
-            f"Adopt a {self.tone} tone "
-            f"talk {self.topic} language  "
-            f"Express {self.emotion} through your word choice and phrasing. "
-            f"start with a {self.hook} or use it and weave it naturally into your message. "
-            f"Use natural speech patterns with appropriate pauses, emphasis through word choice, "
-            f"and conversational fillers like 'you know', 'well', 'actually', etc. according to tone and emotion you are set to do"
-            f"for the topic of conversation maintain what user wants through the session. don't break topic or subject. continue the topic as it goes to real quality conversation"
-            f"don't mention if the user is silent, go on"
+            "You are a mental wellness companion providing supportive, therapy-style conversation. "
+            f"Adopt a {self.tone} tone and focus on {self.topic}. "
+            f"Express yourself in a {self.emotion} manner. "
+            f"Begin with '{self.hook}' or weave it naturally into your response. "
+            "Use short, clear sentences with reflective listening and open-ended questions. "
+            "Avoid medical advice or diagnoses. Continue gently even if the user is silent."
         )
 
     def to_key(self) -> str:


### PR DESCRIPTION
## Summary
- switch strategy component lists to therapy-centric language
- write strategy prompts as a mental wellness companion
- update contextual bandit candidate generation for new hooks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688152c2b7248329b6a6ec7b9504be5d