### PR TITLE
Enable TTS interruption and fix auto‑advance

### DIFF
--- a/ui/pygame_ui.py
+++ b/ui/pygame_ui.py
@@ -579,8 +579,13 @@ class PygameConversationUI:
                 self.sphere.update_trending_words(words)
 
     def handle_speak_button_press(self):
-        """Handle speak button press."""
+        """Handle speak button press with interruption support."""
         if not self.is_recording:
+            if self.orchestrator.ai_speaking:
+                self.logger.info("Interrupting AI to let user speak")
+                self.orchestrator.interrupt_ai_speech()
+                pygame.time.wait(100)
+
             self.is_recording = True
             self.orchestrator.cancel_auto_advance_timer()
             # Small delay to ensure cancellation takes effect
@@ -669,6 +674,7 @@ class PygameConversationUI:
                 if event.key == pygame.K_SPACE:
                     if not self.space_pressed:
                         self.space_pressed = True
+                        # This will now handle interruption automatically
                         self.handle_speak_button_press()
                 elif event.key == pygame.K_TAB:
                     self.show_dashboard = not self.show_dashboard


### PR DESCRIPTION
## Summary
- improve orchestrator auto-advance timer and add `ai_speaking` state
- track speech interruption in `_speak_with_engagement_tracking`
- add early turn end logic for EEG scoring
- support stopping TTS playback mid-stream
- allow UI space bar to interrupt the AI and start recording

## Testing
- `python -m py_compile core/orchestrator.py audio/text_to_speech.py ui/pygame_ui.py eeg/turn_based_engagement_scorer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842aa7b20c83298d33f1a067567ceb