### PR TITLE
Simplify contextual bandit strategy selection

### DIFF
--- a/rl/contextual_bandit.py
+++ b/rl/contextual_bandit.py
@@ -190,6 +190,9 @@ class ContextualBanditAgent:
 
         best_strategy = max(candidates, key=score)
         self.total_selections += 1
+        print(context_type,"context type")
+        print(best_strategy,"strategy")
+        print(candidates,"candidates")
         return best_strategy
 
 
@@ -216,24 +219,39 @@ class ContextualBanditAgent:
         return [last_strategy]
 
     def _get_safe_starter_strategies(self) -> List[Strategy]:
-        """Return a set of starter strategies chosen from the strategy space."""
-        safe_tones = {"kind", "informational"}
-        safe_emotions = {"happy", "serious"}
+        """Return a set of specific starter strategies."""
         starters = [
-            s
-            for s in self.strategy_space.strategies
-            if s.tone in safe_tones and s.emotion in safe_emotions
+            Strategy(
+                tone="warm",
+                topic="professional",  # Pick any topic from config
+                emotion="talk about how this therapy session will go",
+                hook="hey mosh"  # Pick any hook from config
+            ),
+            Strategy(
+                tone="warm",
+                topic="facts",
+                emotion="talk about how this therapy session will go",
+                hook="hello there, good to see you! emmm i mean not quite literally , but anyway"
+            )
         ]
-        if not starters:
-            starters = [self.strategy_space.get_random_strategy()]
-        return starters[:2]
+        return starters
 
     def _get_hook_focused_strategies(self) -> List[Strategy]:
-        """Return strategies emphasizing engaging hooks for auto advance."""
-        favored_hooks = {"you know what?", "listen", "can you believe it?"}
-        hooks = [s for s in self.strategy_space.strategies if s.hook in favored_hooks]
-        if not hooks:
-            hooks = [self.strategy_space.get_random_strategy()]
+        """Return specific strategies with your hardcoded hooks for auto advance."""
+        hooks = [
+            Strategy(
+                tone="confident",  # Pick any tone from config
+                topic="story",  # Pick any topic from config
+                emotion="thoughtful",  # Pick any emotion from config
+                hook="okay, let me explain"
+            ),
+            Strategy(
+                tone="kind",
+                topic="professional",
+                emotion="serious",
+                hook="okay then, let's talk more about this"
+            )
+        ]
         return hooks
 
     def _calculate_contextual_similarity(self, current_context: np.ndarray, historical_context: np.ndarray) -> float:

--- a/rl/contextual_bandit.py
+++ b/rl/contextual_bandit.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import deque, defaultdict
 from typing import List, Tuple, Optional, Dict
 
+
 from rl.strategy import Strategy, StrategySpace
 from .embedding_service import EmbeddingService
 
@@ -171,12 +172,11 @@ class ContextualBanditAgent:
         user_msg = recent_user_msgs[-1] if recent_user_msgs else ""
         user_spoke = len(user_msg.strip()) > 0 and user_msg != "[Silent]"
         context_type = self._classify_context(user_msg, user_spoke)
-
+        print(context_type)
         if context_type == "cold_start":
             candidates = self._get_safe_starter_strategies()
         elif context_type == "auto_advance":
             candidates = self._get_continuation_strategies()
-            candidates.extend(self._get_hook_focused_strategies())
         else:
             candidates = self._get_top_performing_strategies(5)
             if not candidates:
@@ -222,12 +222,14 @@ class ContextualBanditAgent:
         """Return a set of specific starter strategies."""
         starters = [
             Strategy(
+                index=-1,
                 tone="warm",
                 topic="professional",  # Pick any topic from config
                 emotion="talk about how this therapy session will go",
                 hook="hey mosh"  # Pick any hook from config
             ),
             Strategy(
+                index=-1,
                 tone="warm",
                 topic="facts",
                 emotion="talk about how this therapy session will go",
@@ -236,23 +238,6 @@ class ContextualBanditAgent:
         ]
         return starters
 
-    def _get_hook_focused_strategies(self) -> List[Strategy]:
-        """Return specific strategies with your hardcoded hooks for auto advance."""
-        hooks = [
-            Strategy(
-                tone="confident",  # Pick any tone from config
-                topic="story",  # Pick any topic from config
-                emotion="thoughtful",  # Pick any emotion from config
-                hook="okay, let me explain"
-            ),
-            Strategy(
-                tone="kind",
-                topic="professional",
-                emotion="serious",
-                hook="okay then, let's talk more about this"
-            )
-        ]
-        return hooks
 
     def _calculate_contextual_similarity(self, current_context: np.ndarray, historical_context: np.ndarray) -> float:
         """

--- a/rl/contextual_bandit.py
+++ b/rl/contextual_bandit.py
@@ -164,14 +164,15 @@ class ContextualBanditAgent:
     # Strategy selection
     # ------------------------------------------------------------------
     def select_strategy(self) -> Strategy:
-        self.total_selections += 1
         context_vector = self._build_context_vector()
 
-        # Determine context type for smarter candidate generation
+        # Determine context type for smarter candidate generation before
+        # incrementing selections so the cold start case triggers correctly.
         recent_user_msgs, _, _, _ = self.context.get_recent_context(1)
         user_msg = recent_user_msgs[-1] if recent_user_msgs else ""
         user_spoke = len(user_msg.strip()) > 0 and user_msg != "[Silent]"
         context_type = self._classify_context(user_msg, user_spoke)
+        self.total_selections += 1
 
         if context_type == "cold_start":
             candidates = self._get_safe_starter_strategies()


### PR DESCRIPTION
## Summary
- simplify context classification to only handle cold start, auto advance and normal situations
- remove unnecessary candidate generation helpers
- implement candidate selection directly in `select_strategy`

## Testing
- `pytest -q`
- `python -m py_compile rl/contextual_bandit.py`

------
https://chatgpt.com/codex/tasks/task_e_6884330d859083299cb6432350d1ae78