### PR TITLE
feat: add elevenlabs tts option

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,8 @@ load_dotenv()
 
 # API Keys (now loaded from .env file)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
+ELEVENLABS_VOICE_ID = os.getenv("ELEVENLABS_VOICE_ID", "JBFqnCBsd6RMkjVDRZzb")
 
 # Model configurations
 WHISPER_MODEL = "gpt-4o-transcribe"
@@ -72,7 +74,7 @@ AUTO_ADVANCE_TIMEOUT_SEC = 120  # seconds to wait before auto advancing
 HUME_API_KEY = os.getenv("HUME_API_KEY")
 
 # TTS Engine Selection
-TTS_ENGINE = os.getenv("TTS_ENGINE", "openai")  # "openai" or "hume"
+TTS_ENGINE = os.getenv("TTS_ENGINE", "openai")  # "openai", "hume", or "elevenlabs"
 # Contextual Bandit Configuration
 @dataclass
 class ContextualBanditConfig:

--- a/conversation/gpt_wrapper.py
+++ b/conversation/gpt_wrapper.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 import numpy as np
 
 from config import calculate_dynamic_tokens
-from config import GPT_MODEL, MAX_GPT_TOKENS
+from config import GPT_MODEL, MAX_GPT_TOKENS, TTS_ENGINE
 from rl.strategy import Strategy
 
 
@@ -175,6 +175,13 @@ MEMORY CHECK: Before responding, consider:
 3. Are they showing frustration with my approach?
 4. How can I build on their last response rather than starting fresh?
 """
+
+        if TTS_ENGINE.lower() == "elevenlabs":
+            system_prompt += (
+                "\nELEVENLABS TTS GUIDELINES:\n"
+                "- Use ElevenLabs audio tags like [whispers], [laughs], [shout], [sighs].\n"
+                "- Capitalization and punctuation affect delivery.\n"
+            )
 
         # Add risk instructions if statistically significant risk detected
         if risk_instructions:


### PR DESCRIPTION
## Summary
- add ElevenLabs credentials to config and allow selecting it via `TTS_ENGINE`
- implement ElevenLabs-based speech synthesis in `TextToSpeech`
- update GPT prompts to include ElevenLabs audio tags when relevant

## Testing
- `python -m py_compile audio/text_to_speech.py config.py conversation/gpt_wrapper.py`
- `pip install elevenlabs python-dotenv` *(fails: Could not find a version that satisfies the requirement elevenlabs)*

------
https://chatgpt.com/codex/tasks/task_e_68afc1544b6c8329bcfbcbf42055c7d7