### PR TITLE
Fix EmbeddingService cache attribute error

### DIFF
--- a/rl/embedding_service.py
+++ b/rl/embedding_service.py
@@ -15,15 +15,11 @@ class EmbeddingService:
         """Embed any text using OpenAI API with simple caching."""
         if not text.strip():
             return np.zeros(1536)
-        if text in self.cache:
-            return self.cache[text]
         response = self.client.embeddings.create(
             model="text-embedding-3-small",
             input=text
         )
-        embedding = np.array(response.data[0].embedding)
-        self.cache[text] = embedding
-        return embedding
+        return np.array(response.data[0].embedding)
 
 
     def embed_strategy(self, strategy: Strategy) -> np.ndarray:


### PR DESCRIPTION
## Summary
- Remove unused manual cache from `EmbeddingService` to rely on built-in LRU caching and prevent missing attribute errors.

## Testing
- `python -m py_compile rl/embedding_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc78476788329a3f654e728e2ee6c