### PR TITLE
Fix streaming audio interruption and orchestrator concurrency

### DIFF
--- a/audio/text_to_speech.py
+++ b/audio/text_to_speech.py
@@ -110,12 +110,21 @@ class StreamingAudioPlayer:
     def interrupt(self):
         """Interrupt playback immediately."""
         self.interrupted = True
-        # Clear the queue
+        self.playing = False  # Stop playback flag
+
+        # Clear the queue immediately
         while not self.audio_queue.empty():
             try:
                 self.audio_queue.get_nowait()
             except queue.Empty:
                 break
+
+        # Stop the stream immediately
+        if self.stream:
+            try:
+                self.stream.stop_stream()
+            except Exception:
+                pass
 
     def stop_playback(self):
         """Stop playback and cleanup."""

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -91,6 +91,7 @@ class ConversationOrchestrator:
         # Track if a turn is actively being processed
         self.turn_in_progress = False
         self.ai_speaking = False
+        self.processing_lock = asyncio.Lock()  # Prevent concurrent processing
 
         # UI callbacks
         self.ui_callbacks = ui_callbacks or {}
@@ -359,13 +360,19 @@ class ConversationOrchestrator:
             self.ai_speaking = False  # Clear flag immediately
             self.tts.stop()
 
-    async def process_turn(self, audio_data: bytes) -> TurnData:
-        """Process a single conversation turn with turn-based engagement tracking."""
+    async def _process_turn(self, audio_data: bytes) -> TurnData:
+        """Core implementation for processing a single conversation turn."""
 
         # Prevent concurrent turn processing
         if self.turn_in_progress:
             self.logger.warning("Turn already in progress, skipping")
             return
+
+        # IMPORTANT: Stop any ongoing TTS first
+        if self.ai_speaking:
+            self.logger.info("Stopping previous AI speech before new turn")
+            self.tts.stop()
+            await asyncio.sleep(0.2)  # Give time for audio to stop
 
         self.turn_in_progress = True
         try:
@@ -539,6 +546,12 @@ class ConversationOrchestrator:
             self.turn_in_progress = False
             self.start_auto_advance_timer()
 
+    async def process_turn(self, audio_data: bytes) -> TurnData:
+        """Process a single conversation turn with turn-based engagement tracking."""
+
+        async with self.processing_lock:
+            return await self._process_turn(audio_data)
+
     async def run_session(self, client):
         """Run the main conversation session."""
         try:
@@ -609,8 +622,11 @@ class ConversationOrchestrator:
                 and not self.ai_speaking
             ):
                 self.logger.info("Auto-advancing conversation (user silent)")
-                # Create task instead of await to prevent blocking
-                asyncio.create_task(self.process_turn(b""))
+
+                # Use the lock to prevent concurrent processing
+                async with self.processing_lock:
+                    if not self.turn_in_progress and not self.ai_speaking:
+                        await self._process_turn(b"")
 
         except asyncio.CancelledError:
             if "update_countdown" in self.ui_callbacks:


### PR DESCRIPTION
## Summary
- Halt playback immediately on interruption by clearing queue, stopping stream, and updating playing flag
- Guard conversation turns with an async lock and stop any ongoing TTS before starting a new turn
- Prevent simultaneous AI speech during auto-advance by locking and checking state before processing

## Testing
- `python -m py_compile audio/text_to_speech.py core/orchestrator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe28a5988832982cc4521340c941d